### PR TITLE
Added: "match expr with exception e -> action" for OCaml 4.02.2

### DIFF
--- a/ocaml-lang/ocaml-lang.tex
+++ b/ocaml-lang/ocaml-lang.tex
@@ -194,6 +194,7 @@ Module type items:\\
 \verb!  |! \emph{pattern} \verb!->! \emph{action}\\
 \verb!  |! \emph{pattern} \verb!when! \emph{guard} \verb!->! \emph{action}
 & conditional case \\
+\verb!  | exception! \emph{exn} \verb!->! \emph{action} & match exception \\
 \verb!  | _ ->! \emph{action} & default case\\
 \end{tabular}
 Patterns:\\


### PR DESCRIPTION
I have added matching of exceptions in "match ... with" that was introduced in OCaml 4.02.2.
