### PR TITLE
display curly braces in record pattern

### DIFF
--- a/ocaml-lang/ocaml-lang.tex
+++ b/ocaml-lang/ocaml-lang.tex
@@ -147,7 +147,7 @@ Module type items: \Verb!val!, \Verb!external!, \Verb!type!, \Verb!exception!, \
 Patterns:\\
 \begin{tabular}{ll}
 \Verb!| Pair (x,y) ->! & variant pattern \\
-\Verb!| { field = 3; _ } ->! & record pattern \\
+\Verb!| @{ field = 3; _ @} ->! & record pattern \\
 \Verb!| head :: tail ->! & list pattern \\
 \Verb!| [1;2;x] ->! & list pattern \\
 \Verb!| (Some x) as y ->! & with extra binding \\


### PR DESCRIPTION
In the pdf, the curly braces are not displayed for the record pattern. I believe this is an error.

The fix in this PR has not been tested, I don't have the necessary latex setup.
